### PR TITLE
Add --access public to the publish job with provenance

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Publish
         run: |
           pnpm install
-          npm publish --provenance
+          npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Build Changelog


### PR DESCRIPTION
This pull request adds the `--access public` flag to the publish job with provenance because it is required in [the documentation](https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions):

>If you are publishing a package for the first time you will also need to explicitly set access to public:
>```npm publish --provenance --access public```