### PR TITLE
Accept an array of CSS-in-JS objects as a valid input for the addStyle method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.0] - 2024-11-07
+
+- The method `addStyle` now also accepts an array of CSS-in-JS objects
+
 ## [1.0.0] - 2024-11-06
 
 - Release of `home-assistant-styles-manager`

--- a/README.md
+++ b/README.md
@@ -61,9 +61,35 @@ Given a CSS string or a CSS object and an `HTMLElement` or a `ShadowRoot` elemen
 
 ```typescript
 addStyle(
-  css: string | Record<string, Record<string, string> | false>,
+  css: | CSSInJs | CSSInJs[],
   root: HTMLElement | ShadowRoot
 ): void
+```
+
+The `css` property can be a CSS string but also a CSS-in-JS object or an array of CSS-in-JS objects. Any rule with a `false` value will be get hidden.
+
+For eaxample, the next CSS-in-JS object:
+
+```javascript
+{
+  '.some-rule': {
+    backgroundColor: 'red',
+    SomeVariable: '10px'
+  },
+  '.hide-rule': false
+}
+```
+
+Will be compiled to:
+
+```css
+.some-rule {
+  background-color: red;
+  --some-variable: 10px;
+}
+.hide-rule {
+  display: none !important;
+}
 ```
 
 #### removeStyle

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "rollup": "4.21.2",
     "rollup-plugin-ts": "^3.4.5",
     "ts-jest": "^29.2.5",
+    "tslib": "^2.8.1",
     "typescript": "^5.6.2",
     "typescript-eslint": "^8.4.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       ts-jest:
         specifier: ^29.2.5
         version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.9.0))(typescript@5.6.3)
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
       typescript:
         specifier: ^5.6.2
         version: 5.6.3

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export class HomeAssistantStylesManager {
         return utilities.getStyleElement(root, this._prefix);
     }
 
-    public addStyle(css: string | CSSInJs, root: RootElement): void {
+    public addStyle(css: string | CSSInJs | CSSInJs[], root: RootElement): void {
         utilities.addStyle(
             css,
             root,

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -22,7 +22,16 @@ const toKebabCase = (value: string): string => {
     });
 };
 
-// Convert a CSS in JS to string
+const flatCSSInJsArray = (cssRulesInJsArray: CSSInJs[]): CSSInJs => {
+    return cssRulesInJsArray.reduce((flatRules: CSSInJs, rules: CSSInJs): CSSInJs => {
+        flatRules = {
+            ...flatRules,
+            ...rules
+        };
+        return flatRules;
+    }, {});
+};
+
 export const getCSSString = (cssInJs: DeclarationTree): string => {
     return Object.entries(cssInJs)
         .map((entry: [string, string]): string => {
@@ -32,9 +41,11 @@ export const getCSSString = (cssInJs: DeclarationTree): string => {
         .join(';') + ';';
 };
 
-// Convert a CSS rules object to string
-export const getCSSRulesString = (cssRulesInJs: CSSInJs): string => {
-    return Object.entries(cssRulesInJs)
+export const getCSSRulesString = (cssRulesInJs: CSSInJs | CSSInJs[]): string => {
+    const rules = Array.isArray(cssRulesInJs)
+        ? flatCSSInJsArray(cssRulesInJs)
+        : cssRulesInJs;
+    return Object.entries(rules)
         .map((entry: [string, DeclarationTree | false]): string => {
             const [rule, value] = entry;
             if (value === false) {
@@ -68,7 +79,7 @@ export const getStyleElement = (
 };
 
 export const addStyle = (
-    css: string | CSSInJs,
+    css: string | CSSInJs | CSSInJs[],
     root: RootElement | null,
     prefix: string,
     namespace: string

--- a/tests/methods.spec.ts
+++ b/tests/methods.spec.ts
@@ -155,6 +155,25 @@ describe('HomeAssistantStylesManager methods', () => {
             expect(styleElement?.sheet?.cssRules[1].cssText).toBe('.my-element > .child {display: none !important;}');
         });
 
+        it('should update the style element if a new CSS array object is sent to a regular HTMLElement', () => {
+            styleManager.addStyle(
+                [
+                    {
+                        '.my-element': {
+                            background: 'green'
+                        },
+                    },
+                    {
+                        '.my-element > .child': false
+                    }
+                ],
+                myElement
+            );
+            const styleElement = document.querySelector<HTMLStyleElement>('#ha-styles-manager_div');
+            expect(styleElement?.sheet?.cssRules[0].cssText).toBe('.my-element {background: green;}');
+            expect(styleElement?.sheet?.cssRules[1].cssText).toBe('.my-element > .child {display: none !important;}');
+        });
+
         it('should update the style element if a new CSS string is sent to a custom element', () => {
             styleManager.addStyle(
                 `my-custom-element {
@@ -174,6 +193,25 @@ describe('HomeAssistantStylesManager methods', () => {
                     },
                     'my-custom-element + div': false
                 },
+                myCustomElement
+            );
+            const styleElement = document.querySelector<HTMLStyleElement>('#ha-styles-manager_my-custom-html-element');
+            expect(styleElement?.sheet?.cssRules[0].cssText).toBe('my-custom-element {background-color: gray;}');
+            expect(styleElement?.sheet?.cssRules[1].cssText).toBe('my-custom-element + div {display: none !important;}');
+        });
+
+        it('should update the style element if a new CSS array object is sent to a custom element', () => {
+            styleManager.addStyle(
+                [
+                    {
+                        'my-custom-element': {
+                            'background-color': 'gray'
+                        }
+                    },
+                    {
+                        'my-custom-element + div': false
+                    }
+                ],
                 myCustomElement
             );
             const styleElement = document.querySelector<HTMLStyleElement>('#ha-styles-manager_my-custom-html-element');
@@ -201,6 +239,26 @@ describe('HomeAssistantStylesManager methods', () => {
                     },
                     '.custom-li::after': false
                 },
+                myCustomElement?.shadowRoot
+            );
+            const styleElement = myCustomElement?.shadowRoot?.querySelector<HTMLStyleElement>('#ha-styles-manager_my-custom-html-element');
+            expect(styleElement?.sheet?.cssRules[0].cssText).toBe('.custom-li {text-align: right; --webkit-text-fill-color: red;}');
+            expect(styleElement?.sheet?.cssRules[1].cssText).toBe('.custom-li::after {display: none !important;}');
+        });
+
+        it('should update the style element if a new CSS array object is sent to a custom element shadowRoot', () => {
+            styleManager.addStyle(
+                [
+                    {
+                        '.custom-li': {
+                            textAlign: 'right',
+                            WebkitTextFillColor: 'red'
+                        }
+                    },
+                    {
+                        '.custom-li::after': false
+                    }
+                ],
                 myCustomElement?.shadowRoot
             );
             const styleElement = myCustomElement?.shadowRoot?.querySelector<HTMLStyleElement>('#ha-styles-manager_my-custom-html-element');


### PR DESCRIPTION
This pull request makes it possible to send an array of CSS-in-JS objects to the `addStyle` method.