### PR TITLE
Export the `getCSSRulesString` and `getCSSString` utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.1] - 2024-11-07
+
+- Export the `getCSSRulesString` and `getCSSString` utilities
+
 ## [1.1.0] - 2024-11-07
 
 - The method `addStyle` now also accepts an array of CSS-in-JS objects

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,3 +39,4 @@ export class HomeAssistantStylesManager {
 }
 
 export type { RootElement, CSSInJs };
+export { getCSSRulesString, getCSSString } from '@utilities';


### PR DESCRIPTION
This pull request exports the utilities `getCSSRulesString` and `getCSSString` in the published package.