### PR TITLE
Do not throw warnings if there is no style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.0.0] - 2024-11-07
+
+- Do not throw warnings if the element doesn't have a style element in the `removeStyle` method
+
 ## [1.1.1] - 2024-11-07
 
 - Export the `getCSSRulesString` and `getCSSString` utilities

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,4 +39,11 @@ export class HomeAssistantStylesManager {
 }
 
 export type { RootElement, CSSInJs };
-export { getCSSRulesString, getCSSString } from '@utilities';
+
+// These utilities are already tested
+export {
+    /* istanbul ignore next */
+    getCSSRulesString,
+    /* istanbul ignore next */
+    getCSSString
+} from '@utilities';

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -99,7 +99,7 @@ export const addStyle = (
             ? css
             : getCSSRulesString(css);
     } else {
-        console.warn(`${namespace}: not element has been provided in "addStyle"`);
+        console.warn(`${namespace}: no element has been provided in "addStyle"`);
     }
 };
 
@@ -112,10 +112,8 @@ export const removeStyle = (
         const style = getStyleElement(root, prefix);
         if (style) {
             style.remove();
-        } else {
-            console.warn(`${namespace}: not style to remove in "removeStyle"`);
         }
     } else {
-        console.warn(`${namespace}: not element has been provided in "removeStyle"`);
+        console.warn(`${namespace}: no element has been provided in "removeStyle"`);
     }
 };

--- a/tests/custom-namespace.spec.ts
+++ b/tests/custom-namespace.spec.ts
@@ -23,8 +23,6 @@ const BASE_BODY = `
 
 describe('HomeAssistantStylesManager with custom namespace', () => {
 
-    let myElement: HTMLDivElement | null;
-    let myCustomElement: HTMLElement | null;
     let styleManager: HomeAssistantStylesManager;
 
     let consoleWarningFn: jest.Mock;
@@ -40,11 +38,6 @@ describe('HomeAssistantStylesManager with custom namespace', () => {
             .spyOn(console, 'warn')
             .mockImplementation(consoleWarningFn);
         document.body.innerHTML = BASE_BODY;
-        myElement = document.querySelector('.my-element');
-        await customElements.whenDefined('my-custom-html-element')
-            .then(() => {
-                myCustomElement = document.querySelector('my-custom-html-element');
-            });
         styleManager = new HomeAssistantStylesManager({
             namespace: 'custom-namespace'
         });
@@ -64,7 +57,7 @@ describe('HomeAssistantStylesManager with custom namespace', () => {
                 document.querySelector('.non-existent')
             );
 
-            expect(consoleWarningFn).toHaveBeenCalledWith('custom-namespace: not element has been provided in "addStyle"');
+            expect(consoleWarningFn).toHaveBeenCalledWith('custom-namespace: no element has been provided in "addStyle"');
 
         });
 
@@ -78,31 +71,7 @@ describe('HomeAssistantStylesManager with custom namespace', () => {
                 document.querySelector('.non-existent')
             );
 
-            expect(consoleWarningFn).toHaveBeenCalledWith('custom-namespace: not element has been provided in "removeStyle"');
-
-        });
-
-        it('should throw a warning if it is used in an element without style', () => {
-
-            styleManager.removeStyle(myElement);
-
-            expect(consoleWarningFn).toHaveBeenCalledWith('custom-namespace: not style to remove in "removeStyle"');
-
-        });
-
-        it('should throw a warning if it is used in a custom element without style', () => {
-
-            styleManager.removeStyle(myCustomElement);
-
-            expect(consoleWarningFn).toHaveBeenCalledWith('custom-namespace: not style to remove in "removeStyle"');
-
-        });
-
-        it('should throw a warning if it is used in a custom element shadowRoot without style', () => {
-
-            styleManager.removeStyle(myCustomElement?.shadowRoot);
-
-            expect(consoleWarningFn).toHaveBeenCalledWith('custom-namespace: not style to remove in "removeStyle"');
+            expect(consoleWarningFn).toHaveBeenCalledWith('custom-namespace: no element has been provided in "removeStyle"');
 
         });
 

--- a/tests/methods.spec.ts
+++ b/tests/methods.spec.ts
@@ -273,7 +273,7 @@ describe('HomeAssistantStylesManager methods', () => {
                 document.querySelector('.non-existent')
             );
 
-            expect(consoleWarningFn).toHaveBeenCalledWith('home-assistant-styles-manager: not element has been provided in "addStyle"');
+            expect(consoleWarningFn).toHaveBeenCalledWith('home-assistant-styles-manager: no element has been provided in "addStyle"');
 
         });
 
@@ -337,31 +337,7 @@ describe('HomeAssistantStylesManager methods', () => {
                 document.querySelector('.non-existent')
             );
 
-            expect(consoleWarningFn).toHaveBeenCalledWith('home-assistant-styles-manager: not element has been provided in "removeStyle"');
-
-        });
-
-        it('should throw a warning if it is used in an element without style', () => {
-
-            styleManager.removeStyle(notMyElement);
-
-            expect(consoleWarningFn).toHaveBeenCalledWith('home-assistant-styles-manager: not style to remove in "removeStyle"');
-
-        });
-
-        it('should throw a warning if it is used in a custom element without style', () => {
-
-            styleManager.removeStyle(notMyCustomElement);
-
-            expect(consoleWarningFn).toHaveBeenCalledWith('home-assistant-styles-manager: not style to remove in "removeStyle"');
-
-        });
-
-        it('should throw a warning if it is used in a custom element shadowRoot without style', () => {
-
-            styleManager.removeStyle(notMyCustomElement?.shadowRoot);
-
-            expect(consoleWarningFn).toHaveBeenCalledWith('home-assistant-styles-manager: not style to remove in "removeStyle"');
+            expect(consoleWarningFn).toHaveBeenCalledWith('home-assistant-styles-manager: no element has been provided in "removeStyle"');
 
         });
 


### PR DESCRIPTION
This pull request removes the warning that is thrown if an element doesn't have a style when calling the `removeStyle` method.