### PR TITLE
Add a new option to avoid trowing warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.0.0] - 2024-11-07
+
+- New option to avoid throwing warnings
+- Restore the warning when a style element is not present in the `removeStyle` method
+
 ## [2.0.0] - 2024-11-07
 
 - Do not throw warnings if the element doesn't have a style element in the `removeStyle` method

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,10 +11,12 @@ export class HomeAssistantStylesManager {
     constructor(options: Options = {}) {
         this._prefix = options.prefix ?? PREFIX;
         this._namespace = options.namespace ?? NAMESPACE;
+        this._throwWarnings = options.throwWarnings ?? true;
     }
 
     private _prefix: string;
     private _namespace: string;
+    private _throwWarnings: boolean;
     
     public getStyleElement(root: RootElement): HTMLStyleElement | null {
         return utilities.getStyleElement(root, this._prefix);
@@ -25,7 +27,8 @@ export class HomeAssistantStylesManager {
             css,
             root,
             this._prefix,
-            this._namespace
+            this._namespace,
+            this._throwWarnings
         );
     }
 
@@ -33,7 +36,8 @@ export class HomeAssistantStylesManager {
         utilities.removeStyle(
             root,
             this._prefix,
-            this._namespace
+            this._namespace,
+            this._throwWarnings
         );
     }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,4 +5,5 @@ export type CSSInJs = Record<string, DeclarationTree | boolean>;
 export interface Options {
     prefix?: string;
     namespace?: string;
+    throwWarnings?: boolean;
 }

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -82,7 +82,8 @@ export const addStyle = (
     css: string | CSSInJs | CSSInJs[],
     root: RootElement | null,
     prefix: string,
-    namespace: string
+    namespace: string,
+    throwWarnings: boolean
 ): void => {
     if (root) {
         let style = getStyleElement(root, prefix);
@@ -98,22 +99,25 @@ export const addStyle = (
         style.innerHTML = typeof css === 'string'
             ? css
             : getCSSRulesString(css);
-    } else {
-        console.warn(`${namespace}: no element has been provided in "addStyle"`);
+    } else if (throwWarnings) {
+        console.warn(`${namespace}: no element has been provided calling "addStyle"`);
     }
 };
 
 export const removeStyle = (
     root: RootElement | null,
     prefix: string,
-    namespace: string
+    namespace: string,
+    throwWarnings: boolean
 ): void => {
     if (root) {
         const style = getStyleElement(root, prefix);
         if (style) {
             style.remove();
+        } else if (throwWarnings) {
+            console.warn(`${namespace}: no style to remove calling "removeStyle"`);
         }
-    } else {
-        console.warn(`${namespace}: no element has been provided in "removeStyle"`);
+    } else if (throwWarnings) {
+        console.warn(`${namespace}: no element has been provided calling "removeStyle"`);
     }
 };

--- a/tests/custom-namespace.spec.ts
+++ b/tests/custom-namespace.spec.ts
@@ -23,6 +23,8 @@ const BASE_BODY = `
 
 describe('HomeAssistantStylesManager with custom namespace', () => {
 
+    let myElement: HTMLDivElement | null;
+    let myCustomElement: HTMLElement | null;
     let styleManager: HomeAssistantStylesManager;
 
     let consoleWarningFn: jest.Mock;
@@ -38,6 +40,11 @@ describe('HomeAssistantStylesManager with custom namespace', () => {
             .spyOn(console, 'warn')
             .mockImplementation(consoleWarningFn);
         document.body.innerHTML = BASE_BODY;
+        myElement = document.querySelector('.my-element');
+        await customElements.whenDefined('my-custom-html-element')
+            .then(() => {
+                myCustomElement = document.querySelector('my-custom-html-element');
+            });
         styleManager = new HomeAssistantStylesManager({
             namespace: 'custom-namespace'
         });
@@ -57,7 +64,7 @@ describe('HomeAssistantStylesManager with custom namespace', () => {
                 document.querySelector('.non-existent')
             );
 
-            expect(consoleWarningFn).toHaveBeenCalledWith('custom-namespace: no element has been provided in "addStyle"');
+            expect(consoleWarningFn).toHaveBeenCalledWith('custom-namespace: no element has been provided calling "addStyle"');
 
         });
 
@@ -71,7 +78,31 @@ describe('HomeAssistantStylesManager with custom namespace', () => {
                 document.querySelector('.non-existent')
             );
 
-            expect(consoleWarningFn).toHaveBeenCalledWith('custom-namespace: no element has been provided in "removeStyle"');
+            expect(consoleWarningFn).toHaveBeenCalledWith('custom-namespace: no element has been provided calling "removeStyle"');
+
+        });
+
+        it('should throw a warning if it is used in an element without style', () => {
+
+            styleManager.removeStyle(myElement);
+
+            expect(consoleWarningFn).toHaveBeenCalledWith('custom-namespace: no style to remove calling "removeStyle"');
+
+        });
+
+        it('should throw a warning if it is used in a custom element without style', () => {
+
+            styleManager.removeStyle(myCustomElement);
+
+            expect(consoleWarningFn).toHaveBeenCalledWith('custom-namespace: no style to remove calling "removeStyle"');
+
+        });
+
+        it('should throw a warning if it is used in a custom element shadowRoot without style', () => {
+
+            styleManager.removeStyle(myCustomElement?.shadowRoot);
+
+            expect(consoleWarningFn).toHaveBeenCalledWith('custom-namespace: no style to remove calling "removeStyle"');
 
         });
 

--- a/tests/methods.spec.ts
+++ b/tests/methods.spec.ts
@@ -273,7 +273,7 @@ describe('HomeAssistantStylesManager methods', () => {
                 document.querySelector('.non-existent')
             );
 
-            expect(consoleWarningFn).toHaveBeenCalledWith('home-assistant-styles-manager: no element has been provided in "addStyle"');
+            expect(consoleWarningFn).toHaveBeenCalledWith('home-assistant-styles-manager: no element has been provided calling "addStyle"');
 
         });
 
@@ -337,7 +337,7 @@ describe('HomeAssistantStylesManager methods', () => {
                 document.querySelector('.non-existent')
             );
 
-            expect(consoleWarningFn).toHaveBeenCalledWith('home-assistant-styles-manager: no element has been provided in "removeStyle"');
+            expect(consoleWarningFn).toHaveBeenCalledWith('home-assistant-styles-manager: no element has been provided calling "removeStyle"');
 
         });
 

--- a/tests/no-warnings.spec.ts
+++ b/tests/no-warnings.spec.ts
@@ -1,0 +1,90 @@
+import { HomeAssistantStylesManager } from '../src';
+
+class MyCustomHtmlElement extends HTMLElement {
+    constructor() {
+        super();
+    }
+    connectedCallback() {
+        const shadow = this.attachShadow({ mode: 'open' });
+        shadow.innerHTML = `
+            <ul>
+                <li class="custom-li">List item 1</li>
+                <li class="custom-li">List item 2</li>
+                <li class="custom-li">List item 3</li>
+            </ul>
+        `;
+    }
+}
+
+const BASE_BODY = `
+    <div class="my-element">My HTML element</div>
+    <my-custom-html-element></my-custom-html-element>
+`;
+
+describe('HomeAssistantStylesManager no warnings', () => {
+
+    let styleManager: HomeAssistantStylesManager;
+
+    let consoleWarningFn: jest.Mock;
+    let consoleSpy: jest.SpyInstance<void, Parameters<typeof console.warn>>;
+
+    beforeAll(() => {
+        customElements.define('my-custom-html-element', MyCustomHtmlElement);
+    });
+
+    beforeEach(async () => {
+        consoleWarningFn = jest.fn();
+        consoleSpy = jest
+            .spyOn(console, 'warn')
+            .mockImplementation(consoleWarningFn);
+        document.body.innerHTML = BASE_BODY;
+        styleManager = new HomeAssistantStylesManager({
+            throwWarnings: false
+        });
+    });
+
+    afterEach(() => {
+        consoleSpy.mockRestore();
+        document.body.innerHTML = '';
+    });
+
+    describe('addStyle', () => {
+
+        it('should not throw a warning if it is used with a non-existent element', () => {
+
+            styleManager.addStyle(
+                '.custom { display: none }',
+                document.querySelector('.non-existent')
+            );
+
+            expect(consoleWarningFn).not.toHaveBeenCalled();
+
+        });
+
+    });
+
+    describe('removeStyle', () => {
+
+        it('should not throw a warning if it is used with a non-existent element', () => {
+
+            styleManager.removeStyle(
+                document.querySelector('.non-existent')
+            );
+
+            expect(consoleWarningFn).not.toHaveBeenCalled();
+
+        });
+
+        it('should not throw a warning if it is used with no style element', () => {
+
+            styleManager.removeStyle(
+                document.querySelector('.my-element')
+            );
+
+            expect(consoleWarningFn).not.toHaveBeenCalled();
+
+        });
+
+    });
+
+});


### PR DESCRIPTION
This pull request restores the warning when a style element is not present calling the `removeStyle`, but it also adds a new option to avoid throwing warnings.