### PR TITLE
Allow arrays of mixed CSS-in-JS and strings as input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.1.0] - 2024-11-24
+
+- Allow to send an array of CSS in JS objects and strings
+
 ## [3.0.0] - 2024-11-07
 
 - New option to avoid throwing warnings

--- a/README.md
+++ b/README.md
@@ -62,12 +62,12 @@ Given a CSS string or a CSS object and an `HTMLElement` or a `ShadowRoot` elemen
 
 ```typescript
 addStyle(
-  css: string | CSSInJs | CSSInJs[],
+  css: string | CSSInJs | (string | CSSInJs)[],
   root: HTMLElement | ShadowRoot
 ): void
 ```
 
-The `css` property can be a CSS string but also a CSS-in-JS object or an array of CSS-in-JS objects. Any rule with a `false` value will get hidden.
+The `css` property can be a CSS string but also a CSS-in-JS object or an array of CSS-in-JS objects and strings. Any rule with a `false` value will get hidden.
 
 For eaxample, the next CSS-in-JS object:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export class HomeAssistantStylesManager {
         return utilities.getStyleElement(root, this._prefix);
     }
 
-    public addStyle(css: string | CSSInJs | CSSInJs[], root: RootElement): void {
+    public addStyle(css: string | CSSInJs | (string | CSSInJs)[], root: RootElement): void {
         utilities.addStyle(
             css,
             root,

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -22,16 +22,6 @@ const toKebabCase = (value: string): string => {
     });
 };
 
-const flatCSSInJsArray = (cssRulesInJsArray: CSSInJs[]): CSSInJs => {
-    return cssRulesInJsArray.reduce((flatRules: CSSInJs, rules: CSSInJs): CSSInJs => {
-        flatRules = {
-            ...flatRules,
-            ...rules
-        };
-        return flatRules;
-    }, {});
-};
-
 export const getCSSString = (cssInJs: DeclarationTree): string => {
     return Object.entries(cssInJs)
         .map((entry: [string, string]): string => {
@@ -41,18 +31,25 @@ export const getCSSString = (cssInJs: DeclarationTree): string => {
         .join(';') + ';';
 };
 
-export const getCSSRulesString = (cssRulesInJs: CSSInJs | CSSInJs[]): string => {
-    const rules = Array.isArray(cssRulesInJs)
-        ? flatCSSInJsArray(cssRulesInJs)
-        : cssRulesInJs;
-    return Object.entries(rules)
-        .map((entry: [string, DeclarationTree | false]): string => {
+export const getCSSRulesString = (cssRulesInJs: CSSInJs | (string | CSSInJs)[]): string => {
+    const cssInJsArray = Array.isArray(cssRulesInJs)
+        ? cssRulesInJs
+        : [ cssRulesInJs ];
+
+    const cssArray = cssInJsArray.map((item: string | CSSInJs): string => {
+        if (typeof item === 'string') {
+            return item;
+        }
+        return Object.entries(item).map((entry: [string, DeclarationTree | false]): string => {
             const [rule, value] = entry;
             if (value === false) {
                 return `${rule}{display: none !important}`;
             }
             return `${rule}{${getCSSString(value)}}`;
         }).join('');
+    });
+
+    return cssArray.join('');
 };
 
 const getStyleElementId = (
@@ -79,7 +76,7 @@ export const getStyleElement = (
 };
 
 export const addStyle = (
-    css: string | CSSInJs | CSSInJs[],
+    css: string | CSSInJs | (string | CSSInJs)[],
     root: RootElement | null,
     prefix: string,
     namespace: string,

--- a/tests/methods.spec.ts
+++ b/tests/methods.spec.ts
@@ -165,13 +165,15 @@ describe('HomeAssistantStylesManager methods', () => {
                     },
                     {
                         '.my-element > .child': false
-                    }
+                    },
+                    '.my-element > .child::after {content: "";}'
                 ],
                 myElement
             );
             const styleElement = document.querySelector<HTMLStyleElement>('#ha-styles-manager_div');
             expect(styleElement?.sheet?.cssRules[0].cssText).toBe('.my-element {background: green;}');
             expect(styleElement?.sheet?.cssRules[1].cssText).toBe('.my-element > .child {display: none !important;}');
+            expect(styleElement?.sheet?.cssRules[2].cssText).toBe('.my-element > .child::after {content: "";}');
         });
 
         it('should update the style element if a new CSS string is sent to a custom element', () => {


### PR DESCRIPTION
This pull request makes possible to send not only a string, a CSS-in-JS Object or an array of CSS-in-JS objects, but also an array of mixed CSS-in-JS objects and strings.