### PR TITLE
Set cooldown period for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       day: "sunday"
       time: "09:00"
       timezone: "Europe/Amsterdam"
+    cooldown:
+      default-days: 1
     commit-message:
       prefix: "[Dependencies]"
     groups:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,4 @@
 allowBuilds:
   unrs-resolver: false
-minimumReleaseAgeExclude:
-  - ws@8.20.1
 overrides:
   ws@>=8.0.0 <8.20.1: ^8.20.1


### PR DESCRIPTION
This pull request sets [a cooldown period](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-) in the Depndabot configuration to avoid the `pnpm` `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` error because Dependabot updates packages that have been released before the `pnpm` minimum release age.